### PR TITLE
Small addition

### DIFF
--- a/controllers/cards.js
+++ b/controllers/cards.js
@@ -16,11 +16,11 @@ exports.findById = function(req, res) {
 };
 
 exports.findByRarity = function(req, res) {
-	var rarity = req.query.rarity;
-	console.log(req.query.rarity);
-	// Card.find({"rarity": rarity}, function(err, result){
-	// 	return res.send(result);
-	// });
+	var rarity = req.params.type;
+	console.log(rarity);
+	Card.find({"rarity": rarity}, function(err, result){
+		return res.send(result);
+	});
 };
 
 exports.findMythic = function(req, res) {	

--- a/routes.js
+++ b/routes.js
@@ -2,6 +2,7 @@ module.exports = function(app){
 	var cards = require('./controllers/cards');
 	app.get('/cards', cards.findAll);
 	app.get('/cards/:id', cards.findById);
+	app.get('/cards/rarity/:type', cards.findByRarity);
 	app.get('/mythic/', cards.findMythic);
 	app.get('/color', cards.findByRarity);
 	app.get('/rare/', cards.findRare);


### PR DESCRIPTION
Ok,

So you were looking to do a route like `cards/:rarity` but you already had a GET route that was `cards/:id`. So in order to get rid of the all the routes like `/rare` or `/uncommon`, you just need to add a route `/cards/rarity/:type` and get the `:type` from the params. 

So now you can make requests like `localhost:3001/cards/rarity/Uncommon` and it will return what you want. 

I hope that helps. If not find me in the Lab!
